### PR TITLE
Add to block reward explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Producing this certificate is a computationally hard and complex challenge. This
 
 But, given a certificate of legitimacy, it is extremely easy for a third party to verify if it is valid or not. 
 
-For the miners hard work in producing these certificates and executing transactions, they are rewarded in the form of new coins. In Ethereum, when a miner successfully mines a block, they receive 2 ETH for their hard work. 
+For the miners hard work in producing these certificates and executing transactions, they are rewarded in the form of new coins. In Ethereum, when a miner successfully mines a block, they receive 2 ETH for their hard work. Ethereum started with a block reward of 5 ETH, but this was lowered to 3 ETH with the Byzantium upgrade in 2017, and then again down to 2 ETH with the Constantinople upgrade in 2019.
 
 Since decentralized systems lack a central authoirity, the mining process is extremely crucial to the safety and validity of the network. Therefore, the mining reward acts as incentive to participate in the transaction validation process.
 


### PR DESCRIPTION
I think this added context would be helpful. In the Freshman track's lesson "Level 3 - What is ETH" there is an article listed as required reading that has the out-of-date block reward of 5 ETH. This lead to some confusion when I first saw the different block reward in this article.

Sources:
- https://blog.ethereum.org/2017/10/12/byzantium-hf-announcement/
- https://blog.ethereum.org/2019/02/22/ethereum-constantinople-st-petersburg-upgrade-announcement/